### PR TITLE
Upgrade node version in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uuid": "f8c14f6e-0195-46ca-9d6a-eedeac9828da"
   },
   "engines": {
-    "node": ">=18.0.0 <=20.x.x",
+    "node": ">=20.0.0 <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
Closes #6 

The app crashes due to a mismatch between development and railway.